### PR TITLE
Refactor/kanji results

### DIFF
--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -8,9 +8,7 @@ class KanjiResultConverter {
         do {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
-            return KanjiResults.init(
-                status: .error(message: error.localizedDescription)
-            )
+            return KanjiResults.error(message: error.localizedDescription)
         }
     }
 }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -9,7 +9,7 @@ class KanjiResultConverter {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
             return KanjiResults.init(
-                status: .error(message: error.localizedDescription), results: []
+                status: .error(message: error.localizedDescription)
             )
         }
     }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -9,7 +9,7 @@ class KanjiResultConverter {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
             return KanjiResults.init(
-                status: .error(message: error.localizedDescription), count: 0, results: []
+                status: .error(message: error.localizedDescription), results: []
             )
         }
     }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -9,7 +9,7 @@ class KanjiResultConverter {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
             return KanjiResults.init(
-                status: .error, message: error.localizedDescription, count: 0, results: []
+                status: .error(message: error.localizedDescription), message: error.localizedDescription, count: 0, results: []
             )
         }
     }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -9,7 +9,7 @@ class KanjiResultConverter {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
             return KanjiResults.init(
-                status: .error, message: error.localizedDescription, find: false, count: 0, results: []
+                status: .error, message: error.localizedDescription, count: 0, results: []
             )
         }
     }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResultConverter.swift
@@ -9,7 +9,7 @@ class KanjiResultConverter {
             return try decoder.decode(KanjiResults.self, from: json)
         } catch {
             return KanjiResults.init(
-                status: .error(message: error.localizedDescription), message: error.localizedDescription, count: 0, results: []
+                status: .error(message: error.localizedDescription), count: 0, results: []
             )
         }
     }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -12,15 +12,19 @@ struct KanjiResults: Equatable {
 extension KanjiResults: Decodable {
     init(from decorder: Decoder) throws {
         let values = try decorder.container(keyedBy: CodingKeys.self)
-        status = try values.decode(KanjiResultStatus.self, forKey: .status)
+        let status = try values.decode(String.self, forKey: .status)
         switch status {
-        case .success:
+        case "success":
+            self.status = .success
             message = ""
-        case .error:
+        case "error":
             message = try values.decode(String.self, forKey: .message)
+            self.status = .error(message: message)
             count = 0
             results = []
             return
+        default:
+            throw DecodingError.dataCorruptedError(forKey: CodingKeys.status, in: values, debugDescription: "unexpected value \(status)")
         }
         count = try values.decode(Int.self, forKey: .count)
 
@@ -40,7 +44,7 @@ extension KanjiResults: Decodable {
 
 }
 
-enum KanjiResultStatus: String, Codable {
+enum KanjiResultStatus: Equatable {
     case success
-    case error
+    case error(message: String)
 }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -5,7 +5,6 @@ import Foundation
 struct KanjiResults: Equatable {
     var status: KanjiResultStatus
     var message: String
-    var find: Bool
     var count: Int
     var results: [KanjiInfo]
 }
@@ -19,12 +18,10 @@ extension KanjiResults: Decodable {
             message = ""
         case .error:
             message = try values.decode(String.self, forKey: .message)
-            find = false
             count = 0
             results = []
             return
         }
-        find = try values.decode(Bool.self, forKey: .find)
         count = try values.decode(Int.self, forKey: .count)
 
         if values.contains(.results) {
@@ -36,7 +33,6 @@ extension KanjiResults: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case status
-        case find
         case count
         case results
         case message

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -4,7 +4,6 @@ import Foundation
 
 struct KanjiResults: Equatable {
     var status: KanjiResultStatus
-    var count: Int
     var results: [KanjiInfo]
 }
 
@@ -14,12 +13,11 @@ extension KanjiResults: Decodable {
         let status = try values.decode(String.self, forKey: .status)
         switch status {
         case "success":
-            count = try values.decode(Int.self, forKey: .count)
+            let count = try values.decode(Int.self, forKey: .count)
             self.status = .success(count: count)
         case "error":
             let message = try values.decode(String.self, forKey: .message)
             self.status = .error(message: message)
-            count = 0
             results = []
             return
         default:

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -4,7 +4,6 @@ import Foundation
 
 struct KanjiResults: Equatable {
     var status: KanjiResultStatus
-    var message: String
     var count: Int
     var results: [KanjiInfo]
 }
@@ -16,9 +15,8 @@ extension KanjiResults: Decodable {
         switch status {
         case "success":
             self.status = .success
-            message = ""
         case "error":
-            message = try values.decode(String.self, forKey: .message)
+            let message = try values.decode(String.self, forKey: .message)
             self.status = .error(message: message)
             count = 0
             results = []

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -14,7 +14,8 @@ extension KanjiResults: Decodable {
         let status = try values.decode(String.self, forKey: .status)
         switch status {
         case "success":
-            self.status = .success
+            count = try values.decode(Int.self, forKey: .count)
+            self.status = .success(count: count)
         case "error":
             let message = try values.decode(String.self, forKey: .message)
             self.status = .error(message: message)
@@ -24,7 +25,6 @@ extension KanjiResults: Decodable {
         default:
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.status, in: values, debugDescription: "unexpected value \(status)")
         }
-        count = try values.decode(Int.self, forKey: .count)
 
         if values.contains(.results) {
             results = try values.decode(Array<KanjiInfo>.self, forKey: .results)
@@ -43,6 +43,6 @@ extension KanjiResults: Decodable {
 }
 
 enum KanjiResultStatus: Equatable {
-    case success
+    case success(count: Int)
     case error(message: String)
 }

--- a/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
+++ b/KanjiSearcher/source/infrastructure/mojikiban/KanjiResults.swift
@@ -2,10 +2,12 @@
 
 import Foundation
 
-struct KanjiResults: Equatable {
-    var status: KanjiResultStatus
+enum KanjiResults: Equatable {
+    case success(count: Int, results: [KanjiInfo])
+    case error(message: String)
+
     var isEmpty: Bool {
-        switch status {
+        switch self {
         case let .success(_, results):
             return results.isEmpty
         default:
@@ -24,11 +26,10 @@ extension KanjiResults: Decodable {
             let results = values.contains(.results) ?
                 try values.decode(Array<KanjiInfo>.self, forKey: .results) :
                 []
-            self.status = .success(count: count, results: results)
+            self = .success(count: count, results: results)
         case "error":
             let message = try values.decode(String.self, forKey: .message)
-            self.status = .error(message: message)
-            return
+            self = .error(message: message)
         default:
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.status, in: values, debugDescription: "unexpected value \(status)")
         }
@@ -42,9 +43,4 @@ extension KanjiResults: Decodable {
         case message
     }
 
-}
-
-enum KanjiResultStatus: Equatable {
-    case success(count: Int, results: [KanjiInfo])
-    case error(message: String)
 }

--- a/KanjiSearcher/source/result/KanjiSearchStatus.swift
+++ b/KanjiSearcher/source/result/KanjiSearchStatus.swift
@@ -16,10 +16,11 @@ class KanjiSearchError: Error {
     }
 
     init?(kanjiResults: KanjiResults) {
-        if kanjiResults.message.isEmpty {
+        switch kanjiResults.status {
+        case .success:
             return nil
-        } else {
-            self.message = kanjiResults.message
+        case .error(let message):
+            self.message = message
         }
     }
 }

--- a/KanjiSearcher/source/result/KanjiSearchStatus.swift
+++ b/KanjiSearcher/source/result/KanjiSearchStatus.swift
@@ -16,7 +16,7 @@ class KanjiSearchError: Error {
     }
 
     init?(kanjiResults: KanjiResults) {
-        switch kanjiResults.status {
+        switch kanjiResults {
         case .success:
             return nil
         case .error(let message):

--- a/KanjiSearcher/source/result/ResultDataSource.swift
+++ b/KanjiSearcher/source/result/ResultDataSource.swift
@@ -9,7 +9,14 @@ class ResultDataSource: NSObject {
 
 extension ResultDataSource: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return kanjiResults?.count ?? 0
+        switch kanjiResults?.status {
+        case .success(let count):
+            return count
+        case .error:
+            return 0
+        case .none:
+            return 0
+        }
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/KanjiSearcher/source/result/ResultDataSource.swift
+++ b/KanjiSearcher/source/result/ResultDataSource.swift
@@ -9,7 +9,7 @@ class ResultDataSource: NSObject {
 
 extension ResultDataSource: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch kanjiResults?.status {
+        switch kanjiResults {
         case let .success(count, _):
             return count
         case .error:
@@ -24,7 +24,7 @@ extension ResultDataSource: UITableViewDataSource {
         guard let cell = cellOptional as? ResultTableViewCell else {
             return cellOptional
         }
-        switch kanjiResults?.status {
+        switch kanjiResults {
         case .success(_, let results):
             cell.setKanjiInfo(kanjiInfo: results[indexPath.row])
         default:

--- a/KanjiSearcher/source/result/ResultDataSource.swift
+++ b/KanjiSearcher/source/result/ResultDataSource.swift
@@ -10,7 +10,7 @@ class ResultDataSource: NSObject {
 extension ResultDataSource: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch kanjiResults?.status {
-        case .success(let count):
+        case let .success(count, _):
             return count
         case .error:
             return 0
@@ -21,11 +21,15 @@ extension ResultDataSource: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellOptional = tableView.dequeueReusableCell(withIdentifier: "kanjiInfoListItem", for: indexPath)
-        guard let cell = cellOptional as? ResultTableViewCell, let info = kanjiResults?.results[indexPath.row] else {
+        guard let cell = cellOptional as? ResultTableViewCell else {
             return cellOptional
         }
-
-        cell.setKanjiInfo(kanjiInfo: info)
+        switch kanjiResults?.status {
+        case .success(_, let results):
+            cell.setKanjiInfo(kanjiInfo: results[indexPath.row])
+        default:
+            break
+        }
 
         return cell
     }

--- a/KanjiSearcher/source/result/ResultViewModel.swift
+++ b/KanjiSearcher/source/result/ResultViewModel.swift
@@ -79,7 +79,7 @@ class ResultViewModel: ResultViewModelType, ResultViewModelInput, ResultViewMode
             .asDriver(onErrorDriveWith: .empty())
         self.showDetail = self.onSelectItem
             .withLatestFrom(self.successSearching) { indexPath, kanjiResults in
-                switch kanjiResults.status {
+                switch kanjiResults {
                 case let .success(_, results):
                     return results[indexPath.row]
                 default:

--- a/KanjiSearcher/source/result/ResultViewModel.swift
+++ b/KanjiSearcher/source/result/ResultViewModel.swift
@@ -71,16 +71,22 @@ class ResultViewModel: ResultViewModelType, ResultViewModelInput, ResultViewMode
                 }
         }
         self.successSearching = success
-            .filter { !$0.results.isEmpty }
+            .filter { !$0.isEmpty }
             .asDriver(onErrorDriveWith: .empty())
         self.emptySearching = success
-            .filter { $0.results.isEmpty }
+            .filter { $0.isEmpty }
             .map { _ in () }
             .asDriver(onErrorDriveWith: .empty())
         self.showDetail = self.onSelectItem
             .withLatestFrom(self.successSearching) { indexPath, kanjiResults in
-                kanjiResults.results[indexPath.row]
+                switch kanjiResults.status {
+                case let .success(_, results):
+                    return results[indexPath.row]
+                default:
+                    return nil
+                }
         }
+        .compactMap { $0 }
         .asDriver(onErrorDriveWith: .empty())
 
         onQuery

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error, message: "no condition", count: 0, results: [])
+        KanjiResults.init(status: .error(message: "no condition"), message: "no condition", count: 0, results: [])
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error, message: "no condition", find: false, count: 0, results: [])
+        KanjiResults.init(status: .error, message: "no condition", count: 0, results: [])
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error(message: "no condition"), results: [])
+        KanjiResults.init(status: .error(message: "no condition"))
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error(message: "no condition"))
+        KanjiResults.error(message: "no condition")
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error(message: "no condition"), count: 0, results: [])
+        KanjiResults.init(status: .error(message: "no condition"), results: [])
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiRepositoryMock.swift
@@ -6,7 +6,7 @@ import RxSwift
 
 class KanjiRepositoryMock: KanjiRepositoryProtocol {
     var searchCondition: (KanjiQuery) -> KanjiResults = {_ in
-        KanjiResults.init(status: .error(message: "no condition"), message: "no condition", count: 0, results: [])
+        KanjiResults.init(status: .error(message: "no condition"), count: 0, results: [])
     }
 
     func search(query: KanjiQuery) -> Single<KanjiResults> {

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -16,7 +16,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result).to(equal(KanjiResults.init(
-                        status: .error, message: "Invalid Parameters", find: false, count: 0, results: []
+                        status: .error, message: "Invalid Parameters", count: 0, results: []
                     )))
                 }
             }
@@ -29,7 +29,6 @@ class KanjiResultConverterSpec: QuickSpec {
                         .to(equal(KanjiResults.init(
                             status: .success,
                             message: "",
-                            find: false,
                             count: 0,
                             results: [])))
                 }
@@ -40,7 +39,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", find: true, count: 2, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", count: 2, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -74,7 +73,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", find: true, count: 1, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -96,7 +95,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, message: "", find: true, count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -118,7 +117,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, message: "", find: true, count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -16,7 +16,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result).to(equal(KanjiResults.init(
-                        status: .error, message: "Invalid Parameters", count: 0, results: []
+                        status: .error(message: "Invalid Parameters"), message: "Invalid Parameters", count: 0, results: []
                     )))
                 }
             }

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -16,7 +16,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result).to(equal(KanjiResults.init(
-                        status: .error(message: "Invalid Parameters"), message: "Invalid Parameters", count: 0, results: []
+                        status: .error(message: "Invalid Parameters"), count: 0, results: []
                     )))
                 }
             }
@@ -28,7 +28,6 @@ class KanjiResultConverterSpec: QuickSpec {
                     expect(result)
                         .to(equal(KanjiResults.init(
                             status: .success,
-                            message: "",
                             count: 0,
                             results: [])))
                 }
@@ -39,7 +38,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", count: 2, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success, count: 2, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -73,7 +72,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success, count: 1, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -95,7 +94,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success, count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -117,7 +116,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, message: "", count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success, count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -15,9 +15,7 @@ class KanjiResultConverterSpec: QuickSpec {
                     let json = try reader.readJson(fileName: "error_invalid_parameters")
 
                     let result = KanjiResultConverter().convert(json)
-                    expect(result).to(equal(KanjiResults.init(
-                        status: .error(message: "Invalid Parameters")
-                    )))
+                    expect(result).to(equal(.error(message: "Invalid Parameters")))
                 }
             }
             context("no result") {
@@ -26,8 +24,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result)
-                        .to(equal(KanjiResults.init(
-                            status: .success(count: 0, results: []))))
+                        .to(equal(.success(count: 0, results: [])))
                 }
             }
             context("with result") {
@@ -36,7 +33,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2, results: [
+                        expect(result).to(equal(.success(count: 2, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -62,7 +59,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                 ],
                                 strokeCount: 5,
                                 reading: KanjiReading.init(onyomi: [], kunyomi: ["つじ"]))
-                        ]))))
+                        ])))
                     }
                 }
                 context("query is MJ004251 (with empty number)") {
@@ -70,7 +67,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1, results: [
+                        expect(result).to(equal(.success(count: 1, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -84,7 +81,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                 ],
                                 strokeCount: 10,
                                 reading: KanjiReading.init(onyomi: ["ケン"], kunyomi: ["つつしむ"]))
-                        ]))))
+                        ])))
                     }
                 }
                 context("query is MJ013503 (with 2 kanji radicals)") {
@@ -92,7 +89,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1, results: [
+                            .to(equal(.success(count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -106,7 +103,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                     reading: KanjiReading.init(
                                         onyomi: ["ソ", "ソウ", "ゾ"],
                                         kunyomi: ["かつて", "すなわち"]))
-                            ]))))
+                            ])))
                     }
                 }
                 context("query is MJ009387 (with kanji radical that has no stroke)") {
@@ -114,7 +111,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1, results: [
+                            .to(equal(.success(count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,
@@ -128,7 +125,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                     reading: KanjiReading.init(
                                         onyomi: [                    "セイ", "ショウ", "ケイ"],
                                         kunyomi: ["こえ", "こわ"]))
-                            ]))))
+                            ])))
                     }
                 }
             }

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -16,7 +16,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result).to(equal(KanjiResults.init(
-                        status: .error(message: "Invalid Parameters"), count: 0, results: []
+                        status: .error(message: "Invalid Parameters"), results: []
                     )))
                 }
             }
@@ -28,7 +28,6 @@ class KanjiResultConverterSpec: QuickSpec {
                     expect(result)
                         .to(equal(KanjiResults.init(
                             status: .success(count: 0),
-                            count: 0,
                             results: [])))
                 }
             }
@@ -38,7 +37,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2), count: 2, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2), results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -72,7 +71,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1), results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -94,7 +93,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1), results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -116,7 +115,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1), results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -27,7 +27,7 @@ class KanjiResultConverterSpec: QuickSpec {
                     let result = KanjiResultConverter().convert(json)
                     expect(result)
                         .to(equal(KanjiResults.init(
-                            status: .success,
+                            status: .success(count: 0),
                             count: 0,
                             results: [])))
                 }
@@ -38,7 +38,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, count: 2, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2), count: 2, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -72,7 +72,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success, count: 1, results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -94,7 +94,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -116,7 +116,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success, count: 1, results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1), count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,

--- a/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
+++ b/KanjiSearcherTests/source/infrastructure/mojikiban/KanjiResultConverterSpec.swift
@@ -16,7 +16,7 @@ class KanjiResultConverterSpec: QuickSpec {
 
                     let result = KanjiResultConverter().convert(json)
                     expect(result).to(equal(KanjiResults.init(
-                        status: .error(message: "Invalid Parameters"), results: []
+                        status: .error(message: "Invalid Parameters")
                     )))
                 }
             }
@@ -27,8 +27,7 @@ class KanjiResultConverterSpec: QuickSpec {
                     let result = KanjiResultConverter().convert(json)
                     expect(result)
                         .to(equal(KanjiResults.init(
-                            status: .success(count: 0),
-                            results: [])))
+                            status: .success(count: 0, results: []))))
                 }
             }
             context("with result") {
@@ -37,7 +36,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_つじ")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2), results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 2, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ025761"),
                                 idInFamilyRegister: 437750,
@@ -63,7 +62,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                 ],
                                 strokeCount: 5,
                                 reading: KanjiReading.init(onyomi: [], kunyomi: ["つじ"]))
-                        ])))
+                        ]))))
                     }
                 }
                 context("query is MJ004251 (with empty number)") {
@@ -71,7 +70,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ004251")
 
                         let result = KanjiResultConverter().convert(json)
-                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1), results: [
+                        expect(result).to(equal(KanjiResults.init(status: .success(count: 1, results: [
                             KanjiInfo.init(
                                 kanjiId: KanjiId(fullId: "MJ004251"),
                                 idInFamilyRegister: nil,
@@ -85,7 +84,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                 ],
                                 strokeCount: 10,
                                 reading: KanjiReading.init(onyomi: ["ケン"], kunyomi: ["つつしむ"]))
-                        ])))
+                        ]))))
                     }
                 }
                 context("query is MJ013503 (with 2 kanji radicals)") {
@@ -93,7 +92,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ013503")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1), results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ013503"),
                                     idInFamilyRegister: nil,
@@ -107,7 +106,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                     reading: KanjiReading.init(
                                         onyomi: ["ソ", "ソウ", "ゾ"],
                                         kunyomi: ["かつて", "すなわち"]))
-                            ])))
+                            ]))))
                     }
                 }
                 context("query is MJ009387 (with kanji radical that has no stroke)") {
@@ -115,7 +114,7 @@ class KanjiResultConverterSpec: QuickSpec {
                         let json = try reader.readJson(fileName: "query_MJ文字図形名_MJ009387")
                         let result = KanjiResultConverter().convert(json)
                         expect(result)
-                            .to(equal(KanjiResults.init(status: .success(count: 1), results: [
+                            .to(equal(KanjiResults.init(status: .success(count: 1, results: [
                                 KanjiInfo.init(
                                     kanjiId: KanjiId(fullId: "MJ009387"),
                                     idInFamilyRegister: 064630,
@@ -129,8 +128,7 @@ class KanjiResultConverterSpec: QuickSpec {
                                     reading: KanjiReading.init(
                                         onyomi: [                    "セイ", "ショウ", "ケイ"],
                                         kunyomi: ["こえ", "こわ"]))
-                            ])))
-
+                            ]))))
                     }
                 }
             }

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success(count: 0), results: [])
+                        KanjiResults.init(status: .success(count: 0, results: []))
                     }
 
                     scheduler
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), results: [])
+                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"))
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams
@@ -107,8 +107,14 @@ class ResultViewModelSpec: QuickSpec {
                                 .createObserver(with: viewModel.output.showDetail, disposedBy: disposeBag)
 
                             scheduler.start()
-                            expect(observer.events)
-                                .to(equal([.next(20, result.results[1])]))
+
+                            switch result.status {
+                            case let .success(_, results):
+                                expect(observer.events)
+                                    .to(equal([.next(20, results[1])]))
+                            default:
+                                fail()
+                            }
                         }
                     }
                 }

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success(count: 0, results: []))
+                        .success(count: 0, results: [])
                     }
 
                     scheduler
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"))
+                        let errorInvalidParams = KanjiResults.error(message: "Invalid Parameters")
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams
@@ -108,7 +108,7 @@ class ResultViewModelSpec: QuickSpec {
 
                             scheduler.start()
 
-                            switch result.status {
+                            switch result {
                             case let .success(_, results):
                                 expect(observer.events)
                                     .to(equal([.next(20, results[1])]))

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success, count: 0, results: [])
+                        KanjiResults.init(status: .success(count: 0), count: 0, results: [])
                     }
 
                     scheduler

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success, message: "", find: false, count: 0, results: [])
+                        KanjiResults.init(status: .success, message: "", count: 0, results: [])
                     }
 
                     scheduler
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error, message: "Invalid Parameters", find: false, count: 0, results: [])
+                        let errorInvalidParams = KanjiResults.init(status: .error, message: "Invalid Parameters", count: 0, results: [])
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error, message: "Invalid Parameters", count: 0, results: [])
+                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), message: "Invalid Parameters", count: 0, results: [])
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success, message: "", count: 0, results: [])
+                        KanjiResults.init(status: .success, count: 0, results: [])
                     }
 
                     scheduler
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), message: "Invalid Parameters", count: 0, results: [])
+                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), count: 0, results: [])
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams

--- a/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
+++ b/KanjiSearcherTests/source/result/ResultViewModelSpec.swift
@@ -23,7 +23,7 @@ class ResultViewModelSpec: QuickSpec {
             context("with なにもない (get no result)") {
                 it("drives success") {
                     kanjiRepositoryMock.searchCondition = { _ in
-                        KanjiResults.init(status: .success(count: 0), count: 0, results: [])
+                        KanjiResults.init(status: .success(count: 0), results: [])
                     }
 
                     scheduler
@@ -47,7 +47,7 @@ class ResultViewModelSpec: QuickSpec {
                 }
                 context("get error for invalid parameters") {
                     it("drives error") {
-                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), count: 0, results: [])
+                        let errorInvalidParams = KanjiResults.init(status: .error(message: "Invalid Parameters"), results: [])
 
                         kanjiRepositoryMock.searchCondition = { _ in
                             errorInvalidParams


### PR DESCRIPTION
KanjiResults has mixed properties.
They are used on success or on error, both.

KanjiReuslts become enum and properties are used only .success or .error.